### PR TITLE
WIP: Docker and GitLab deployment support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,11 @@
+stages:
+  - deploy
+
+deploy:
+  image:
+    name: docker/compose:1.24.1
+    entrypoint: ["/bin/sh", "-c"]
+  stage: deploy
+  script:
+    - docker-compose build
+    - BOT_TOKEN=$BOT_TOKEN docker-compose up -d

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM ruby:2.6
+
+WORKDIR /app
+COPY . .
+
+RUN bundle install
+
+CMD ["ruby", "bot.rb"]

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org' do
     gem 'discordrb'
-    gem 'hangman', 'https://github.com/DarkyOMG/Hangman'
+    gem 'hangman', git: 'https://github.com/DarkyOMG/Hangman'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org' do
     gem 'discordrb'
+    gem 'hangman', 'https://github.com/DarkyOMG/Hangman'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org' do
+    gem 'discordrb'
+end

--- a/bot.rb
+++ b/bot.rb
@@ -1,7 +1,7 @@
 require 'discordrb'
 require_relative 'hangman'
 
-token = (File.read("token.txt").split)[0]
+token = ENV["BOT_TOKEN"] || (File.read("token.txt").split)[0]
 
 bot = Discordrb::Bot.new token: token
 

--- a/bot.rb
+++ b/bot.rb
@@ -1,5 +1,9 @@
 require 'discordrb'
-require_relative 'hangman'
+begin
+  require 'hangman'
+rescue LoadError
+  require_relative 'hangman'
+end
 
 token = ENV["BOT_TOKEN"] || (File.read("token.txt").split)[0]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+version: "3"
+
 services:
   gilly:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,5 @@
+services:
+  gilly:
+    build: .
+    environment:
+      - BOT_TOKEN


### PR DESCRIPTION
_Work in Progress: The Hangman project still needs to be gem-ified_

This PR adds Docker support and a GitLab CI configuration. To use, setup the secret environment variable `BOT_TOKEN` in your GitLab configuration.